### PR TITLE
corrected dependency naming for operating systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Add the dependencies:
 dependencies {
     implementation("net.janrupf.ultralight:ultralight-java-reborn-core:0.0.1-SNAPSHOT")
     implementation("net.janrupf.ultralight:ultralight-java-reborn-platform-jni:0.0.1-SNAPSHOT:linux-x64")
-    // or windows-x64, macos-x64, or just add all 3 as dependencies
+    // or win-x64, mac-x64, or just add all 3 as dependencies
 }
 ```
 
@@ -75,7 +75,7 @@ Add the dependencies:
         <artifactId>ultralight-java-reborn-platform-jni</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <classifier>linux-x64</classifier>
-        <!-- or windows-x64, macos-x64, or just add all 3 as dependencies -->
+        <!-- or win-x64, mac-x64, or just add all 3 as dependencies -->
     </dependency>
 </dependencies>
 ```


### PR DESCRIPTION
I have replaced "windows-x64" with "win-x64" and "macos" with "mac" for the following repository link: https://s01.oss.sonatype.org/content/repositories/snapshots/net/janrupf/ultralight/ultralight-java-reborn-platform-jni/0.0.1-SNAPSHOT/

This correction will help prevent any potential confusion regarding the correct names of the supported operating systems.